### PR TITLE
add AWSCore 0.1 lower bound to REQUIRE

### DIFF
--- a/REQUIRE
+++ b/REQUIRE
@@ -1,3 +1,4 @@
 julia 0.5
-AWSCore
+AWSCore 0.1
 SymDict
+XMLDict


### PR DESCRIPTION
since it's the first version where AWSConfig is defined

also add direct dependency on XMLDict which is imported but not
directly depended on (assumed to be present as transitive dep)